### PR TITLE
Add ability to use sandbox OAuth credentials to authenticate to EBay.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,15 @@ Note: The examples are for a Rails 3 app.
 
 ```ruby
     Rails.application.config.middleware.use OmniAuth::Builder do
-       provider :ebay, "runame", "devid", "appid", "certid", "siteid", "apiurl", "auth_type"
+       provider :ebay, "runame", "devid", "appid", "certid", "siteid", "environment", "auth_type"
     end
 ```
 
 Insert your app credentials in the given order. You can find out these details by going into your developer's account at [eBay DevZone](https://developer.ebay.com/DevZone/account/)
 
-`auth_type` - The only optional argument when initializing the strategy, by default it's configured to SSO(SingleSignOn),
+`environment` - Defaults to `:production` and other valid option is `:sandbox`
+
+`auth_type` - An optional argument when initializing the strategy, by default it's configured to SSO(SingleSignOn),
 and should be changed to AuthType::Simple (SignIn), as it's the standard option.
 
 * To use the strategy, you will need to access it's omniauth provider path: `/auth/ebay`. The callback phase path is the default one: `/auth/ebay/callback`.

--- a/lib/ebay_api.rb
+++ b/lib/ebay_api.rb
@@ -13,7 +13,27 @@ module EbayAPI
     end
   end
 
-  EBAY_LOGIN_URL = "https://signin.ebay.com/ws/eBayISAPI.dll"
+  EBAY_PRODUCTION_LOGIN_URL = "https://signin.ebay.com/ws/eBayISAPI.dll"
+  EBAY_SANDBOX_LOGIN_URL = "https://signin.sandbox.ebay.com/ws/eBayISAPI.dll"
+
+  EBAY_PRODUCTION_XML_API_URL = "https://api.ebay.com/ws/api.dll"
+  EBAY_SANDBOX_XML_API_URL = "https://api.sandbox.ebay.com/ws/api.dll"
+
+
+  def sandbox?
+    options.environment == :sandbox
+  end
+
+  def login_url
+    return EBAY_SANDBOX_LOGIN_URL if sandbox?
+    EBAY_PRODUCTION_LOGIN_URL
+  end
+
+  def api_url
+    return EBAY_SANDBOX_XML_API_URL if sandbox?
+    EBAY_PRODUCTION_XML_API_URL
+  end
+
   X_EBAY_API_REQUEST_CONTENT_TYPE = 'text/xml'
   X_EBAY_API_COMPATIBILITY_LEVEL = '675'
   X_EBAY_API_GETSESSIONID_CALL_NAME = 'GetSessionID'
@@ -83,7 +103,6 @@ module EbayAPI
   end
 
   def ebay_login_url(session_id, ruparams={})
-    login_url = options.loginurl || EBAY_LOGIN_URL
     url = "#{login_url}?#{options.auth_type}&runame=#{options.runame}&#{session_id_field_name}=#{URI.escape(session_id).gsub('+', '%2B')}"
 
     ruparams[:internal_return_to] = internal_return_to if internal_return_to
@@ -97,7 +116,7 @@ module EbayAPI
 
   def api(call_name, request)
     headers = ebay_request_headers(call_name, request.length.to_s)
-    url = URI.parse(options.apiurl)
+    url = URI.parse(api_url)
     req = Net::HTTP::Post.new(url.path, headers)
     http = Net::HTTP.new(url.host, url.port)
     http.use_ssl = true

--- a/lib/omniauth/strategies/ebay.rb
+++ b/lib/omniauth/strategies/ebay.rb
@@ -14,16 +14,15 @@ module OmniAuth
         SIMPLE_SID_FIELD_NAME = "SessId"
       end
 
-      args [:runame, :devid, :appid, :certid, :siteid, :apiurl, :auth_type, :loginurl]
+      args [:runame, :devid, :appid, :certid, :siteid, :environment, :auth_type]
       option :name, "ebay"
       option :runame, nil
       option :devid, nil
       option :appid, nil
       option :certid, nil
       option :siteid, nil
-      option :apiurl, nil
+      option :environment, :production
       option :auth_type, AuthType::SSO
-      option :loginurl, nil
 
       uid { raw_info['EIASToken'] }
       info do

--- a/spec/lib/ebay_api_spec.rb
+++ b/spec/lib/ebay_api_spec.rb
@@ -32,40 +32,62 @@ describe EbayAPI do
       subject.ebay_login_url(unescaped_session_id).should include("sid=#{CGI.escape(unescaped_session_id)}")
     end
 
-    context :SingleSignOn do
-      it "should return ebay login url with internal return to when internal_return_to given in request" do
+    context :sandbox do
+      it "should return the sandbox ebay login/api urls when sandbox environment is specified" do
         subject.stub(:internal_return_to) { internal_return_to }
         params = {}
         params[:internal_return_to] = internal_return_to
         params[:sid] = session_id
-        subject.ebay_login_url(session_id).should == "#{EbayAPI::EBAY_LOGIN_URL}?#{singleSignOn}&runame=runame&sid=#{session_id}&ruparams=#{to_query(params)}"
-      end
-
-      it "should return ebay login url without internal return to when internal_return_to isn't given in request" do
-        subject.stub(:internal_return_to) { false }
-        params = {}
-        params[:sid] = session_id
-        subject.ebay_login_url(session_id).should == "#{EbayAPI::EBAY_LOGIN_URL}?#{singleSignOn}&runame=runame&sid=#{session_id}&ruparams=#{to_query(params)}"
+        subject.options.environment = :sandbox
+        subject.login_url.should == EbayAPI::EBAY_SANDBOX_LOGIN_URL
+        subject.api_url.should == EbayAPI::EBAY_SANDBOX_XML_API_URL
       end
     end
 
-    context :SignIn do
-      before :each do
-        subject.options.auth_type = OmniAuth::Strategies::Ebay::AuthType::Simple
-      end
-      it "should return ebay login url with internal_return_to when internal_return_to given in request" do
+    context :production do
+      it "should return the production login/api urls when production environment is specified" do
         subject.stub(:internal_return_to) { internal_return_to }
         params = {}
         params[:internal_return_to] = internal_return_to
         params[:sid] = session_id
-        subject.ebay_login_url(session_id).should == "#{EbayAPI::EBAY_LOGIN_URL}?#{signIn}&runame=runame&SessId=#{session_id}&ruparams=#{to_query(params)}"
+        subject.login_url.should == EbayAPI::EBAY_PRODUCTION_LOGIN_URL
+        subject.api_url.should == EbayAPI::EBAY_PRODUCTION_XML_API_URL
+      end
+      context :SingleSignOn do
+        it "should return ebay login url with internal return to when internal_return_to given in request" do
+          subject.stub(:internal_return_to) { internal_return_to }
+          params = {}
+          params[:internal_return_to] = internal_return_to
+          params[:sid] = session_id
+          subject.ebay_login_url(session_id).should == "#{EbayAPI::EBAY_PRODUCTION_LOGIN_URL}?#{singleSignOn}&runame=runame&sid=#{session_id}&ruparams=#{to_query(params)}"
+        end
+
+        it "should return ebay login url without internal return to when internal_return_to isn't given in request" do
+          subject.stub(:internal_return_to) { false }
+          params = {}
+          params[:sid] = session_id
+          subject.ebay_login_url(session_id).should == "#{EbayAPI::EBAY_PRODUCTION_LOGIN_URL}?#{singleSignOn}&runame=runame&sid=#{session_id}&ruparams=#{to_query(params)}"
+        end
       end
 
-      it "should return ebay login url without internal return to when internal_return_to isn't given in request" do
-        subject.stub(:internal_return_to) { false }
-        params = {}
-        params[:sid] = session_id
-        subject.ebay_login_url(session_id).should == "#{EbayAPI::EBAY_LOGIN_URL}?#{signIn}&runame=runame&SessId=#{session_id}&ruparams=#{to_query(params)}"
+      context :SignIn do
+        before :each do
+          subject.options.auth_type = OmniAuth::Strategies::Ebay::AuthType::Simple
+        end
+        it "should return ebay login url with internal_return_to when internal_return_to given in request" do
+          subject.stub(:internal_return_to) { internal_return_to }
+          params = {}
+          params[:internal_return_to] = internal_return_to
+          params[:sid] = session_id
+          subject.ebay_login_url(session_id).should == "#{EbayAPI::EBAY_PRODUCTION_LOGIN_URL}?#{signIn}&runame=runame&SessId=#{session_id}&ruparams=#{to_query(params)}"
+        end
+
+        it "should return ebay login url without internal return to when internal_return_to isn't given in request" do
+          subject.stub(:internal_return_to) { false }
+          params = {}
+          params[:sid] = session_id
+          subject.ebay_login_url(session_id).should == "#{EbayAPI::EBAY_PRODUCTION_LOGIN_URL}?#{signIn}&runame=runame&SessId=#{session_id}&ruparams=#{to_query(params)}"
+        end
       end
     end
 


### PR DESCRIPTION
I've made the environment optional, defaulting to production, so that users of this gem can test their code in the sandbox before using it in a production environment.  Note there is a change to the arguments in the omniauth initializer - I didn't think passing the API url was all that useful and should be derived from the environment flag with this change.  AFAIK the EBay XML API doesn't really change.

Tests and docs have been updated in line with code changes, let me know what you think.
